### PR TITLE
ValidateFormat: do not html.Unescape and trim spaces

### DIFF
--- a/checkmail.go
+++ b/checkmail.go
@@ -35,8 +35,7 @@ var (
 )
 
 func ValidateFormat(email string) error {
-	formatOk := emailRegexp.MatchString(email)
-	if !formatOk {
+	if !emailRegexp.MatchString(email) {
 		return ErrBadFormat
 	}
 	return nil

--- a/checkmail.go
+++ b/checkmail.go
@@ -69,7 +69,7 @@ func ValidateHost(email string) error {
 }
 
 func split(email string) (account, host string) {
-	i := strings.LastIndex(email, "@")
+	i := strings.LastIndexByte(email, '@')
 	account = email[:i]
 	host = email[i+1:]
 	return

--- a/checkmail.go
+++ b/checkmail.go
@@ -3,7 +3,6 @@ package checkmail
 import (
 	"errors"
 	"fmt"
-	"html"
 	"net"
 	"net/smtp"
 	"regexp"
@@ -36,8 +35,6 @@ var (
 )
 
 func ValidateFormat(email string) error {
-	email = html.UnescapeString(strings.TrimSpace(email))
-
 	formatOk := emailRegexp.MatchString(email)
 	if !formatOk {
 		return ErrBadFormat

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -28,6 +28,10 @@ var (
 
 func TestValidateHost(t *testing.T) {
 	for _, s := range samples {
+		if !s.format {
+			continue
+		}
+
 		err := checkmail.ValidateHost(s.mail)
 		if err != nil && s.account == true {
 			t.Errorf(`"%s" => unexpected error: "%v"`, s.mail, err)

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -13,11 +13,14 @@ var (
 		account bool //host+user
 	}{
 		{mail: "florian@carrere.cc", format: true, account: true},
+		{mail: " florian@carrere.cc", format: false, account: false},
+		{mail: "florian@carrere.cc ", format: false, account: false},
 		{mail: "test@912-wrong-domain902.com", format: true, account: false},
 		{mail: "0932910-qsdcqozuioqkdmqpeidj8793@gmail.com", format: true, account: false},
 		{mail: "@gmail.com", format: false, account: false},
 		{mail: "test@gmail@gmail.com", format: false, account: false},
 		{mail: "test test@gmail.com", format: false, account: false},
+		{mail: " test@gmail.com", format: false, account: false},
 		{mail: "test@wrong domain.com", format: false, account: false},
 		{mail: "é&ààà@gmail.com", format: false, account: false},
 	}


### PR DESCRIPTION
Do not html.Unescape and trim spaces because:
1. This should not be the job of this library and is not an expectation of users of the function
2. This has the risk of allowing nasty encodings and dirty exploits

This PR contains also a few other small commits. Tell me if you prefer I separate them.