### PR TITLE
feat: add function ValidateHostAndUser to validate host and user preventing SPAN and BOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ for prevent SPAN and BOTS.
 ```go
 func main() {
     var (
-        serverHostName    = "smtp.myserver.com"
-        serverMailAddress = "validuser@myserver.com"
+        serverHostName    = "smtp.myserver.com" // set your SMTP server here
+        serverMailAddress = "validuser@myserver.com"  // set your valid mail address here
     )
     err := checkmail.ValidateHostAndUser(serverHostName, serverMailAddress, "unknown-user-129083726@gmail.com")
     if smtpErr, ok := err.(checkmail.SmtpError); ok && err != nil {

--- a/README.md
+++ b/README.md
@@ -11,34 +11,42 @@
 
 ### 1. Format
 ```go
-    func main() {
-		err := checkmail.ValidateFormat("ç$€§/az@gmail.com")
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
+func main() {
+    err := checkmail.ValidateFormat("ç$€§/az@gmail.com")
+    if err != nil {
+        fmt.Println(err)
+    }
+}
 ```
 output: `invalid format`
 
 ### 2. Domain
 ```go
-    func main() {
-		err := checkmail.ValidateHost("email@x-unkown-domain.com")
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
+func main() {
+    err := checkmail.ValidateHost("email@x-unkown-domain.com")
+    if err != nil {
+        fmt.Println(err)
+    }
+}
 ```
 output: `unresolvable host`
 
-### 3. User
+### 3. Host and User
+
+If host is valid, requires valid SMTP `serverHostName` (see to [online validator](https://mxtoolbox.com/SuperTool.aspx)) and `serverMailAddress` to reverse validation 
+for prevent SPAN and BOTS.
+
 ```go
-    func main() {
-		err := checkmail.ValidateHost("unknown-user-129083726@gmail.com")
-		if smtpErr, ok := err.(checkmail.SmtpError); ok && err != nil {
-			fmt.Printf("Code: %s, Msg: %s", smtpErr.Code(), smtpErr)
-		}
-	}
+func main() {
+    var (
+        serverHostName    = "smtp.myserver.com"
+        serverMailAddress = "validuser@myserver.com"
+    )
+    err := checkmail.ValidateHostAndUser(serverHostName, serverMailAddress, "unknown-user-129083726@gmail.com")
+    if smtpErr, ok := err.(checkmail.SmtpError); ok && err != nil {
+        fmt.Printf("Code: %s, Msg: %s", smtpErr.Code(), smtpErr)
+    }
+}
 ```
 output: `Code: 550, Msg: 550 5.1.1 The email account that you tried to reach does not exist.`
 

--- a/checkmail.go
+++ b/checkmail.go
@@ -37,6 +37,7 @@ var (
 	emailRegexp = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 )
 
+
 func ValidateFormat(email string) error {
 	if !emailRegexp.MatchString(email) {
 		return ErrBadFormat
@@ -44,24 +45,42 @@ func ValidateFormat(email string) error {
 	return nil
 }
 
+// ValidateHost validate mail host.
 func ValidateHost(email string) error {
 	_, host := split(email)
 	mx, err := net.LookupMX(host)
 	if err != nil {
 		return ErrUnresolvableHost
 	}
+	client, err := DialTimeout(fmt.Sprintf("%s:%d", mx[0].Host, 25), forceDisconnectAfter)
+	if err != nil {
+		return NewSmtpError(err)
+	}
+	client.Close()
+	return nil
+}
 
+// ValidateHostAndUser validate mail host and user.
+// If host is valid, requires valid SMTP [1] serverHostName and serverMailAddress to reverse validation
+// for prevent SPAN and BOTS.
+// [1] https://mxtoolbox.com/SuperTool.aspx
+func ValidateHostAndUser(serverHostName, serverMailAddress, email string) error {
+	_, host := split(email)
+	mx, err := net.LookupMX(host)
+	if err != nil {
+		return ErrUnresolvableHost
+	}
 	client, err := DialTimeout(fmt.Sprintf("%s:%d", mx[0].Host, 25), forceDisconnectAfter)
 	if err != nil {
 		return NewSmtpError(err)
 	}
 	defer client.Close()
 
-	err = client.Hello("checkmail.me")
+	err = client.Hello(serverHostName)
 	if err != nil {
 		return NewSmtpError(err)
 	}
-	err = client.Mail("lansome-cowboy@gmail.com")
+	err = client.Mail(serverMailAddress)
 	if err != nil {
 		return NewSmtpError(err)
 	}

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -1,9 +1,10 @@
-package checkmail_test
+package checkmail
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
-	"github.com/badoux/checkmail"
 )
 
 var (
@@ -35,7 +36,27 @@ func TestValidateHost(t *testing.T) {
 			continue
 		}
 
-		err := checkmail.ValidateHost(s.mail)
+		err := ValidateHost(s.mail)
+		if err != nil && s.account == true {
+			t.Errorf(`"%s" => unexpected error: "%v"`, s.mail, err)
+		}
+		if err == nil && s.account == false {
+			t.Errorf(`"%s" => expected error`, s.mail)
+		}
+	}
+}
+
+func TestValidateHostAndUser(t *testing.T) {
+	var (
+		serverHostName = getenv(t, "self_hostname")
+		serverMailAddress = getenv(t, "self_mail")
+	)
+	for _, s := range samples {
+		if !s.format {
+			continue
+		}
+
+		err := ValidateHostAndUser(serverHostName, serverMailAddress, s.mail)
 		if err != nil && s.account == true {
 			t.Errorf(`"%s" => unexpected error: "%v"`, s.mail, err)
 		}
@@ -47,7 +68,7 @@ func TestValidateHost(t *testing.T) {
 
 func TestValidateFormat(t *testing.T) {
 	for _, s := range samples {
-		err := checkmail.ValidateFormat(s.mail)
+		err := ValidateFormat(s.mail)
 		if err != nil && s.format == true {
 			t.Errorf(`"%s" => unexpected error: "%v"`, s.mail, err)
 		}
@@ -55,4 +76,12 @@ func TestValidateFormat(t *testing.T) {
 			t.Errorf(`"%s" => expected error`, s.mail)
 		}
 	}
+}
+
+func getenv(t *testing.T, name string) (value string) {
+	name = "test_checkmail_"+name
+	if value = os.Getenv(name); value =="" {
+		panic(fmt.Errorf("enviroment variable %q is not defined", name))
+	}
+	return
 }


### PR DESCRIPTION
I'm using the function `ValidateHost` to validates host and user in my server, bot, my server provider forwarded this alert to me:

> This is an abuse report for an email message sent by IP XXX.XXX.XXX.XXX on Thu, 18 Jun 2020 21:16:22 -0300
> This abuse appears to be a spoofing attack or its sender has a wrong SPF configuration for sure.
> If you have any question about this abuse, contact the anti-spam administrator <admin@spfbl.net>.
> For more information about this abuse format below, see https://tools.ietf.org/html/rfc5965
> Feedback-Type: abuse
> User-Agent: SPFBL/2.11
> Version: 1
> Original-Mail-From: lansome-cowboy@gmail.com
> Original-Rcpt-To: vendas@tecmarespumas.com.br
> Arrival-Date: Thu, 18 Jun 2020 21:16:22 -0300
> Reporting-MTA: dns; mx-br.spfbl.net
> Source-IP: XXX.XXX.XXX.XXX
> Authentication-Results: mx-br.spfbl.net; smtp.mail=**lansome-cowboy@gmail.com**; spf=softfail
> Removal-Recipient: xxxxxxx@server.com
> This email message was rejected at RCPT TO command, so we don't have its headers. 

I noticed that the email informed in the message was the one set in the ValidateHost function. So, I made the following changes:

1. the ValidateHost function now validates only the host of the email address and no longer the user, since it does not require a valid SMTP domain to return.
2. I created the ValidateHostAndUser function that requires the arguments `serverHostName` and `serverMailAddress`.

In this way it makes it possible to validate according to each application and hosting server of the same, not using your pre-fixed email address (`lansome-cowboy@gmail.com`) and not even a host that did not exist (`checkmail.me`) .