### PR TITLE
Create separate function to just validate MX records

### DIFF
--- a/checkmail.go
+++ b/checkmail.go
@@ -45,6 +45,16 @@ func ValidateFormat(email string) error {
 	return nil
 }
 
+// ValidateMX validate if MX record exists for a domain.
+func ValidateMX(email string) error {
+	_, host := split(email)
+	if _, err := net.LookupMX(host); err != nil {
+		return ErrUnresolvableHost
+	}
+
+	return nil
+}
+
 // ValidateHost validate mail host.
 func ValidateHost(email string) error {
 	_, host := split(email)

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -46,6 +46,22 @@ func TestValidateHost(t *testing.T) {
 	}
 }
 
+func TestValidateMX(t *testing.T) {
+	for _, s := range samples {
+		if !s.format {
+			continue
+		}
+
+		err := ValidateMX(s.mail)
+		if err != nil && s.account == true {
+			t.Errorf(`"%s" => unexpected error: "%v"`, s.mail, err)
+		}
+		if err == nil && s.account == false {
+			t.Errorf(`"%s" => expected error`, s.mail)
+		}
+	}
+}
+
 func TestValidateHostAndUser(t *testing.T) {
 	var (
 		serverHostName = getenv(t, "self_hostname")


### PR DESCRIPTION
Some Cloud providers block port 25 in order to prevent email spam, so it might be useful to be able to validate MX records without validating connectivity to MX host.

For instance AWS EC2 instances have port 25 restrictions by default and to remove them you have to provide "valid case" - https://aws.amazon.com/premiumsupport/knowledge-center/ec2-port-25-throttle/.
