### PR TITLE
Add check in split utility method to prevent panic

### DIFF
--- a/checkmail.go
+++ b/checkmail.go
@@ -117,6 +117,10 @@ func DialTimeout(addr string, timeout time.Duration) (*smtp.Client, error) {
 
 func split(email string) (account, host string) {
 	i := strings.LastIndexByte(email, '@')
+	// If no @ present, not a valid email.
+	if i < 0 {
+		return
+	}
 	account = email[:i]
 	host = email[i+1:]
 	return

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -27,6 +27,7 @@ var (
 		{mail: "é&ààà@gmail.com", format: false, account: false},
 		{mail: "admin@busyboo.com", format: true, account: false},
 		{mail: "a@gmail.fi", format: true, account: false},
+		{mail: "", format: false, account: false},
 	}
 )
 

--- a/checkmail_test.go
+++ b/checkmail_test.go
@@ -25,9 +25,10 @@ var (
 		{mail: " test@gmail.com", format: false, account: false},
 		{mail: "test@wrong domain.com", format: false, account: false},
 		{mail: "é&ààà@gmail.com", format: false, account: false},
-		{mail: "admin@busyboo.com", format: true, account: false},
-		{mail: "a@gmail.fi", format: true, account: false},
+		{mail: "admin@notarealdomain12345.com", format: true, account: false},
+		{mail: "a@gmail.xyz", format: true, account: false},
 		{mail: "", format: false, account: false},
+		{mail: "not-a-valid-email", format: false, account: false},
 	}
 )
 


### PR DESCRIPTION
This line panics when i = -1, which happens when not a valid email:
```
       account = email[i:]
	host = email[i+1:]
```

Add a few more testcases for this check and update some test cases.
